### PR TITLE
Update react-motion to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nodemon": "^1.3.7",
     "react": "^0.14.0-rc1",
     "react-blessed": "^0.1.4",
-    "react-motion": "^0.2.7",
+    "react-motion": "^0.3.1",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.7.0"
   },

--- a/src/components/AnimatedBox.js
+++ b/src/components/AnimatedBox.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Spring } from 'react-motion';
+import { Motion, spring } from 'react-motion';
 import { rgbToHex, interpolateColor } from '../utils/colors';
 
 const colors = {
@@ -62,9 +62,9 @@ export default class AnimatedBox extends Component {
 
   render() {
     return (
-      <Spring endValue={this.state.position}>
-        {val => <Square position={val} />}
-      </Spring>
+      <Motion style={{x: spring(this.state.position)}}>
+        {val => <Square position={val.x} />}
+      </Motion>
     );
   }
 }


### PR DESCRIPTION
Updates the react-motion dependency to 0.3.1, which moves over to the new API. Specific changes (Spring -> Motion) are informed by: https://github.com/chenglou/react-motion/wiki/v0.3.0-examples#normal-spring
