### PR TITLE
Fix key handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,8 @@ webpack(backendConfig).watch(100, function(err, stats) {
       script: path.join(__dirname, 'build', 'backend'),
       ignore: ['*'],
       watch: ['foo/'],
-      ext: 'noop'
+      ext: 'noop',
+      restartable: false
     });
   }
 

--- a/server.js
+++ b/server.js
@@ -59,6 +59,10 @@ webpack(backendConfig).watch(100, function(err, stats) {
       watch: ['foo/'],
       ext: 'noop',
       restartable: false
+    }).on('error', function(code) {
+      if (code !== 2) {
+        console.log('Exited with error code: ', code);
+      }
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const screen = blessed.screen({
 
 // Let user quit the app
 screen.key(['escape', 'q', 'C-c'], function(ch, key) {
-  return process.exit(0);
+  return process.exit(2);
 });
 
 // Render React component into screen


### PR DESCRIPTION
Hi Dan, thanks for putting this demo together!

I am developing a console app and need to handle key events. By default nodemon eats all the keystrokes (so that it allows explicit restart by typing `rs`) and keys do not work in the app.

This PR fixes that by making nodemon to forward key events to the app and also fixes exiting so that when you type `q` or `Esc` the app exits (using exit code 2 which makes nodemon to quit, otherwise the app would quit but nodemon would spawn it again).