### PR TITLE
Make Square class extend React.Component to quiet a warning

### DIFF
--- a/src/components/AnimatedBox.js
+++ b/src/components/AnimatedBox.js
@@ -21,7 +21,7 @@ const colors = {
   base0F: '#d27b53'
 };
 
-class Square {
+class Square extends Component {
   render() {
     const { position } = this.props;
     return (


### PR DESCRIPTION
Minor change to prevent a warning from React:

```
$ npm start

> react-blessed-hot-motion@ start /Users/jon/Desktop/react-blessed-hot-motion
> node server.js

Warning: Square(...): React component classes must extend React.Component.
```

I tested this change with react@0.14.9 and it makes the warning go away.